### PR TITLE
import sets module statement executed only for python version >=3

### DIFF
--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -70,11 +70,11 @@
 from __future__ import print_function
 import sys, re, os
 from templates import *
-from sets import Set
 
 if sys.version_info[0] >= 3:
     from io import StringIO
 else:
+    from sets import Set
     from cStringIO import StringIO
 
 


### PR DESCRIPTION
Python sets module was deprecated from Python 2.6 and was removed from Python3: the import statement is executed only for Python version >= 3
